### PR TITLE
Replace pipeline slugs with ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Changed
+- [PR#28](https://github.com/EmbarkStudios/buildkite-jobify/pull/28) changed up how pipelines are specified, instead of specifying a slug, the user must specify the unique GraphQL pipeline ID that can be found in the pipeline's settings page (or via the GraphQL API). This means that the there is also no longer a need to specify the organization since pipelines are no longer queried for.
+
 ## [0.5.1] - 2021-03-12
 ### Changed
 - Cluster can now be specified in the config as well as the CLI.

--- a/buildkite/jobs.gql
+++ b/buildkite/jobs.gql
@@ -1,22 +1,15 @@
-# Finds a pipeline by its name, the search is extremely
-# limited, so we get up to 10 matches and find the one
-# we actually want from that
-query FindPipeline($org: ID!) {
-  node(id: $org) {
+# Gets a pipeline via its identifier. You can locate the pipeline identifier in
+# the general settings for the pipeline
+query GetPipelineById($id: ID!) {
+  node(id: $id) {
     __typename
-    ... on Organization {
-      pipelines(first: 100) {
-        edges {
-          node {
-            id
-            name
-            slug
-            description
-            repository {
-              url
-            }
-          }
-        }
+    ... on Pipeline {
+      id
+      name
+      slug
+      description
+      repository {
+        url
       }
     }
   }

--- a/src/jobifier.rs
+++ b/src/jobifier.rs
@@ -176,8 +176,6 @@ struct JobInfo<'a> {
     bk_job: &'a monitor::Job,
     /// The slug for the pipeline the job is part of
     pipeline: &'a str,
-    /// The slug for the organization the pipeline is a part of
-    org: &'a str,
     /// The agent description that will execute the job
     agent: &'a Agent,
 }
@@ -193,7 +191,6 @@ async fn spawn_job<'a>(
     let labels = {
         let mut labels = BTreeMap::new();
         labels.insert("bk-jobify".to_owned(), "true".to_owned());
-        labels.insert("bk-org".to_owned(), nfo.org.to_owned());
         labels.insert("bk-pipeline".to_owned(), nfo.pipeline.to_owned());
         labels
     };
@@ -405,7 +402,6 @@ fn get_best_agent<'a>(
 async fn cleanup_jobs(kbctl: APIClient, namespace: String, pipeline: String) -> Result<u32, Error> {
     // We just aggressively delete all pods that match our labels, instead
     // of more carefully only deleting pods for jobs that are known to be completed
-
     let label_selector = format!("bk-jobify=true,bk-pipeline={}", pipeline);
 
     // TODO: Use watches
@@ -542,7 +538,6 @@ async fn jobify(
                                 let job_info = JobInfo {
                                     bk_job: job,
                                     pipeline: &builds.pipeline,
-                                    org: &builds.org,
                                     agent,
                                 };
 


### PR DESCRIPTION
Rather than doing multiple queries for both the organization, as well as finding pipelines by their slug/name, instead we just expect the user to directly specify the pipeline IDs they wish to monitor for builds which is easily discoverable in the pipeline's settings page. This removes the need to specify the organization since pipeline ids are globally unique, and means we don't have to query for pipelines, just the exact one we want.